### PR TITLE
Fix autoplaylists sample

### DIFF
--- a/js/list.js
+++ b/js/list.js
@@ -849,8 +849,12 @@ function _list(mode, x, y, w, h) {
 						i++;
 					}
 				}
-				plman.CreateAutoPlaylist(plman.PlaylistCount, n, q, s, f ? 1 : 0);
-				plman.ActivePlaylist = plman.PlaylistCount - 1;
+				try {
+					plman.CreateAutoPlaylist(plman.PlaylistCount, n, q, s, f ? 1 : 0);
+					plman.ActivePlaylist = plman.PlaylistCount - 1;
+				} catch (e) {
+					fb.ShowPopupMessage(`${e}`);
+				}
 			}
 			
 			_createFolder(folders.data);


### PR DESCRIPTION
I didn't realise the behaviour of plman,CreateAutoplaylist had changed. In JSP it used to silently fail and return a new playlist index of -1 to indicate failure. SMP throws errors which must be caught.